### PR TITLE
Ensure script exits when showing usage

### DIFF
--- a/abiquo-server/abiquo-liquibase
+++ b/abiquo-server/abiquo-liquibase
@@ -96,7 +96,7 @@ case $PARAM in
             -u MySQL user
             -p MySQL password
 EOT
-    RETURN=0
+    exit 0 
 esac
 
 if [ $RETURN == 0 ]; then


### PR DESCRIPTION
When running with no params this was upgrading accounting schema