### PR TITLE
Mark accounting cron as config

### DIFF
--- a/abiquo-server/abiquo-server.spec
+++ b/abiquo-server/abiquo-server.spec
@@ -64,6 +64,7 @@ rm -rf $RPM_BUILD_ROOT
 %{abiquo_basedir}/config/examples/abiquo.properties.server
 %{_bindir}/abiquo-liquibase
 %{_bindir}/lqb_update_from_26.sh
+%config(noreplace) /etc/cron.d/abiquo-accounting
 
 %changelog
 * Fri Aug 07 2015 rpmbaker <sergio.pena+rpmbaker@abiquo.com> 3.6.0-1


### PR DESCRIPTION
In systems where DB is on a sepparate server this file will be
changed, so avoid overwritting in each upgrade.