### PR TITLE
Fix virtual factory cloudinit dependency

### DIFF
--- a/abiquo-virtualfactory/abiquo-virtualfactory.spec
+++ b/abiquo-virtualfactory/abiquo-virtualfactory.spec
@@ -14,7 +14,7 @@ Source0:  ../../virtualfactory.war
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch: noarch
 
-Requires: abiquo-core genisofs
+Requires: abiquo-core genisoimage
 
 %description
 Next Generation Cloud Management Solution


### PR DESCRIPTION
mkisofs, required by virtualfactory cloudinit feature is in genisoimage package, not genisofs. Pointy hat for me :(